### PR TITLE
Fix QStrings from filechoosers

### DIFF
--- a/vistrails/gui/collection/workspace.py
+++ b/vistrails/gui/collection/workspace.py
@@ -218,11 +218,11 @@ class QCollectionWidget(QtGui.QTreeWidget):
         self.collection.commit()
 
     def add_file(self):
-        s = QtGui.QFileDialog.getOpenFileName(
+        s = str(QtGui.QFileDialog.getOpenFileName(
                     self, "Choose a file",
-                    "", "Vistrail files (*.vt *.xml)");
-        if str(s):
-            locator = FileLocator(str(s))
+                    "", "Vistrail files (*.vt *.xml)"))
+        if s:
+            locator = FileLocator(s)
             url = locator.to_url()
             entity = self.collection.updateVistrail(url)
             # add to relevant workspace categories
@@ -230,11 +230,11 @@ class QCollectionWidget(QtGui.QTreeWidget):
             self.collection.commit()
         
     def add_dir(self):
-        s = QtGui.QFileDialog.getExistingDirectory(
+        s = str(QtGui.QFileDialog.getExistingDirectory(
                     self, "Choose a directory",
-                    "", QtGui.QFileDialog.ShowDirsOnly);
-        if str(s):
-            self.update_from_directory(str(s))
+                    "", QtGui.QFileDialog.ShowDirsOnly))
+        if s:
+            self.update_from_directory(s)
         
     def update_from_directory(self, s):
         filenames = glob.glob(os.path.join(s, '*.vt,*.xml'))

--- a/vistrails/gui/mashups/mashup_app.py
+++ b/vistrails/gui/mashups/mashup_app.py
@@ -284,7 +284,6 @@ Pipeline results: %s' % (len(cellEvents), self.numberOfCells, errors))
         if not folder.isEmpty():
             self.dumpcells = str(folder)
             self.saveAll()
-            self.lastExportPath
     
     def saveAndExport(self, clicked=True):
         self.saveAll()

--- a/vistrails/gui/publishing.py
+++ b/vistrails/gui/publishing.py
@@ -215,7 +215,7 @@ class QLatexAssistant(QtGui.QWidget, QVistrailsPaletteInterface):
                                                   'LaTeX files (*.tex)')
         if fname and not fname.isEmpty():
             self.source_edit.setText(fname)
-            self.texts = parse_latex_file(fname)
+            self.texts = parse_latex_file(str(fname))
             for cmd_tuple in self.texts[1]:
                 if cmd_tuple:
                     opt_dict = parse_vt_command(*cmd_tuple)

--- a/vistrails/gui/uvcdat/colormapEditorWidget.py
+++ b/vistrails/gui/uvcdat/colormapEditorWidget.py
@@ -354,9 +354,9 @@ class QColormapEditor(QtGui.QColorDialog):
         self.cellsDirty = True
 
     def save(self):
-        out = QtGui.QFileDialog.getSaveFileName(self, "JSON File",
-                                                filter="json Files (*.json *.jsn *.JSN *.JSON) ;; All Files (*.*)",
-                                                options=QtGui.QFileDialog.DontConfirmOverwrite)
+        out = str(QtGui.QFileDialog.getSaveFileName(self, "JSON File",
+                                                    filter="json Files (*.json *.jsn *.JSN *.JSON) ;; All Files (*.*)",
+                                                    options=QtGui.QFileDialog.DontConfirmOverwrite))
         cmap = self.activeCanvas.getcolormap(str(self.colormap.currentText()))
         cmap.script(out)
 

--- a/vistrails/gui/uvcdat/definedVariableWidget.py
+++ b/vistrails/gui/uvcdat/definedVariableWidget.py
@@ -395,7 +395,7 @@ class QDefinedVariableWidget(QtGui.QWidget):
         sel = self.getSelectedDefinedVariables()
         if len(sel)==0:
             return
-        out = QtGui.QFileDialog.getSaveFileName(self,"NetCDF File",filter="NetCDF Files (*.nc *.cdg *.NC *.CDF *.nc4 *.NC4) ;; All Files (*.*)",options=QtGui.QFileDialog.DontConfirmOverwrite)
+        out = str(QtGui.QFileDialog.getSaveFileName(self,"NetCDF File",filter="NetCDF Files (*.nc *.cdg *.NC *.CDF *.nc4 *.NC4) ;; All Files (*.*)",options=QtGui.QFileDialog.DontConfirmOverwrite))
         mode = "w"
         if os.path.exists(out):
             overwrite = QtGui.QMessageBox.question(self,"Existing File","Do you want to append to it or overwrite it?","Append","Overwrite","Ooops",2)
@@ -407,7 +407,7 @@ class QDefinedVariableWidget(QtGui.QWidget):
         c = self.cursor()
         self.setCursor(QtCore.Qt.BusyCursor)
         try:
-            fo = cdms2.open(str(out),mode)
+            fo = cdms2.open(out,mode)
             for v in sel:
                 fo.write(v)
             fo.close()

--- a/vistrails/gui/uvcdat/uvcdatCommons.py
+++ b/vistrails/gui/uvcdat/uvcdatCommons.py
@@ -484,7 +484,7 @@ class QCommandsFileWidget(QtGui.QDialog):
     def saveAs(self):
         cont = True
         while cont is True:
-            fnm = QtGui.QFileDialog.getSaveFileName()
+            fnm = str(QtGui.QFileDialog.getSaveFileName())
             try:
                 f=open(fnm,'w')
                 cont=False

--- a/vistrails/packages/CLTools/wizard.py
+++ b/vistrails/packages/CLTools/wizard.py
@@ -259,10 +259,10 @@ class QCLToolsWizard(QtGui.QWidget):
         self.setTitle()
     
     def openFile(self):
-        fileName = QtGui.QFileDialog.getOpenFileName(self,
+        fileName = str(QtGui.QFileDialog.getOpenFileName(self,
                 "Open Wrapper",
                 self.file if self.file else default_dir(),
-                "Wrappers (*%s)" % SUFFIX)
+                "Wrappers (*%s)" % SUFFIX))
         if not fileName:
             return
         try:
@@ -333,7 +333,7 @@ class QCLToolsWizard(QtGui.QWidget):
                             "Save Wrapper as",
                             self.file if self.file else default_dir(),
                             "Wrappers (*%s)" % SUFFIX)
-        if fileName:
+        if not fileName.isEmpty():
             self.file = str(fileName)
             if not self.file.endswith(SUFFIX):
                 self.file += SUFFIX

--- a/vistrails/packages/spreadsheet/spreadsheet_cell.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_cell.py
@@ -356,9 +356,8 @@ class QCellToolBar(QtGui.QToolBar):
             filename = QtGui.QFileDialog.getSaveFileName(
                 self, "Save cell as...",
                 ".", ';;'.join(cell.save_formats))
-            if filename:
-                filename = str(filename)
-                cell.dumpToFile(filename)
+            if not filename.isEmpty():
+                cell.dumpToFile(str(filename))
 
     def createToolBar(self):
         """ createToolBar() -> None

--- a/vistrails/packages/spreadsheet/spreadsheet_tabcontroller.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_tabcontroller.py
@@ -975,7 +975,7 @@ class StandardWidgetTabController(QtGui.QTabWidget):
                                                      '(*.vss)',
                                                      )
         if not fileName.isNull():
-            self.openSpreadsheet(fileName)
+            self.openSpreadsheet(str(fileName))
 
     def cleanup(self):
         """ cleanup() -> None

--- a/vistrails/packages/vtDV3D/CDMS_DatasetReaders.py
+++ b/vistrails/packages/vtDV3D/CDMS_DatasetReaders.py
@@ -1320,7 +1320,7 @@ class CDMSDatasetConfigurationWidget(DV3DConfigurationWidget):
     def selectFile(self):
         dataset = None
         file = QFileDialog.getOpenFileName( self, "Find Dataset", os.path.expanduser('~'), "CDMS Files (*.xml *.cdms *.nc *.nc4)") 
-        if file <> None:
+        if not file.isNull():
             cdmsFile = str( file ).strip() 
             if len( cdmsFile ) > 0:                             
                 try:


### PR DESCRIPTION
You are using sip QString API v1, so Qt returns Qt objects, not native `unicode` objects.

Fixes UV-CDAT/uvcdat#957
