### PR TITLE
Fix vtkcell on X11 for VTK >=6.2

### DIFF
--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -343,10 +343,10 @@ class QVTKWidget(QCellWidget):
                 try:
                     vp = '_%s_void_p' % (hex(int(QtGui.QX11Info.display()))[2:])
                 except TypeError:
-                    #This was change for PyQt4.2
-                    if isinstance(QtGui.QX11Info.display(),QtGui.Display):
-                        display = sip.unwrapinstance(QtGui.QX11Info.display())
-                        vp = '_%s_void_p' % (hex(display)[2:])
+                    # This was changed for PyQt4.2
+                    assert isinstance(QtGui.QX11Info.display(), QtGui.Display)
+                    display = sip.unwrapinstance(QtGui.QX11Info.display())
+                    vp = '_%s_void_p' % (hex(display)[2:])
                 v = vtk.vtkVersion()
                 version = [v.GetVTKMajorVersion(),
                            v.GetVTKMinorVersion(),

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -341,18 +341,22 @@ class QVTKWidget(QCellWidget):
                 self.mRenWin.Finalize()
             if system.systemType=='Linux':
                 try:
-                    vp = '_%s_void_p' % (hex(int(QtGui.QX11Info.display()))[2:])
+                    display = int(QtGui.QX11Info.display())
                 except TypeError:
                     # This was changed for PyQt4.2
                     assert isinstance(QtGui.QX11Info.display(), QtGui.Display)
                     display = sip.unwrapinstance(QtGui.QX11Info.display())
-                    vp = '_%s_void_p' % (hex(display)[2:])
                 v = vtk.vtkVersion()
                 version = [v.GetVTKMajorVersion(),
                            v.GetVTKMinorVersion(),
                            v.GetVTKBuildVersion()]
+                display = hex(display)[2:]
                 if version < [5, 7, 0]:
-                    vp = vp + '\0x00'                
+                    vp = ('_%s_void_p\0x00' % display)
+                elif version < [6, 2, 0]:
+                    vp = ('_%s_void_p' % display)
+                else:
+                    vp = ('_%s_p_void' % display)
                 self.mRenWin.SetDisplayId(vp)
                 self.resizeWindow(1,1)
             self.mRenWin.SetWindowInfo(str(int(self.winId())))  


### PR DESCRIPTION
Fixes UV-CDAT/uvcdat#1019

I can't really test this, on my build I get a segmentation faults when I plot (but after SetDisplayId :wink:):

```
SetDisplayId('_29213e0_p_void')
success
bin/uvcdat: line 4:  3833 Segmentation fault      python2.7 "/home/vagrant/builds/66cfd540b480efeaba2b8b59f97ee2d1f89de1c4/install/vistrails/vistrails/uvcdat.py" "$@"
```
