### PR TITLE
Configure button enables 2D Interaction

### DIFF
--- a/vistrails/gui/uvcdat/plot.py
+++ b/vistrails/gui/uvcdat/plot.py
@@ -55,8 +55,9 @@ class PlotProperties(QtGui.QDockWidget):
 
         if canvas is not None:
             if canvas not in self.configuring_canvases:
-                canvas.configure()
                 self.configuring_canvases.append(canvas)
+            if self.isVisible():
+                canvas.configure()
 
     def getCanvas(self):
         if self.controller is None:

--- a/vistrails/gui/uvcdat/plot.py
+++ b/vistrails/gui/uvcdat/plot.py
@@ -51,6 +51,17 @@ class PlotProperties(QtGui.QDockWidget):
         # we need to reset the title in case there were changes
         self.setWindowTitle("Visualization Properties")
     
+    def getCanvas(self):
+        sheetName, row, col = self.controller.get_current_cell_info()
+        #get cell widget
+        cellWidget = None
+        sheetWidget = self.controller.get_sheet_widget(sheetName)
+        if sheetWidget is not None:
+            cellWidget = sheetWidget.getCell(row, col)
+            if cellWidget is not None:
+                return cellWidget.canvas
+        return None
+
     def configureDone(self, action):
         self.controller.plot_properties_were_changed(self.sheetName,
                                                      self.row, self.col,
@@ -83,6 +94,9 @@ class PlotProperties(QtGui.QDockWidget):
         self.updateLocked = False
         
     def closeEvent(self, event):
+        canvas = self.getCanvas()
+        if canvas is not None:
+            canvas.endconfigure()
         self.confWidget.askToSaveChanges()
         event.accept()
         
@@ -94,12 +108,15 @@ class PlotProperties(QtGui.QDockWidget):
         self.confWidget.activate()
         
     def set_visible(self, enabled):
-        #print "set_visible ", self, enabled
+
         if hasattr(self, 'main_window') and self.main_window is not None:
             self.main_window.show()
             self.main_window.raise_()
 
         if enabled:
             self.show()
+            canvas = self.getCanvas()
+            if canvas is not None:
+                canvas.configure()
             self.raise_()
             self.setFloating(True)

--- a/vistrails/gui/uvcdat/plot.py
+++ b/vistrails/gui/uvcdat/plot.py
@@ -15,28 +15,29 @@ class PlotProperties(QtGui.QDockWidget):
         self.updateLocked = False
         self.hasChanges = False
         self.sheetName = None
+        self.configuring_canvases = []
         self.row = -1
         self.col = -1
-        
+
     @classmethod
     def instance(klass, parent=None):
         if not hasattr(klass, '_instance'):
             klass._instance = klass(parent)
         return klass._instance
-        
+
     def set_controller(self, controller):
         self.controller = controller
         self.updateProperties(None)
 
     def sizeHint(self):
         return QtCore.QSize(512, 512)
-    
+
     def updateProperties(self, widget=None, sheetName=None, row=-1, col=-1):
         if self.updateLocked: return
         self.sheetName = sheetName
         self.row = row
         self.col = col
-        self.confWidget.setUpdatesEnabled(False)    
+        self.confWidget.setUpdatesEnabled(False)
         self.confWidget.setVisible(False)
         self.confWidget.clear()
         if widget and self.controller:
@@ -50,8 +51,16 @@ class PlotProperties(QtGui.QDockWidget):
         self.hasChanges = False
         # we need to reset the title in case there were changes
         self.setWindowTitle("Visualization Properties")
-    
+        canvas = self.getCanvas()
+
+        if canvas is not None:
+            if canvas not in self.configuring_canvases:
+                canvas.configure()
+                self.configuring_canvases.append(canvas)
+
     def getCanvas(self):
+        if self.controller is None:
+            return None
         sheetName, row, col = self.controller.get_current_cell_info()
         #get cell widget
         cellWidget = None
@@ -66,7 +75,7 @@ class PlotProperties(QtGui.QDockWidget):
         self.controller.plot_properties_were_changed(self.sheetName,
                                                      self.row, self.col,
                                                      action)
-    
+
     def stateChanged(self):
         self.hasChanges = self.confWidget.widget.state_changed
         # self.setWindowModified seems not to work here
@@ -78,35 +87,35 @@ class PlotProperties(QtGui.QDockWidget):
         else:
             if title.endswith("*"):
                 self.setWindowTitle(title[:-1])
-        
+
     def lockUpdate(self):
         """ lockUpdate() -> None
         Do not allow updateModule()
-        
+
         """
         self.updateLocked = True
-        
+
     def unlockUpdate(self):
         """ unlockUpdate() -> None
         Allow updateModule()
-        
+
         """
         self.updateLocked = False
-        
+
     def closeEvent(self, event):
-        canvas = self.getCanvas()
-        if canvas is not None:
+        for canvas in self.configuring_canvases:
             canvas.endconfigure()
+        self.configuring_canvases = []
         self.confWidget.askToSaveChanges()
         event.accept()
-        
+
     def activate(self):
         if self.isVisible() == False:
             # self.toolWindow().show()
             self.show()
         self.activateWindow()
         self.confWidget.activate()
-        
+
     def set_visible(self, enabled):
 
         if hasattr(self, 'main_window') and self.main_window is not None:
@@ -115,8 +124,7 @@ class PlotProperties(QtGui.QDockWidget):
 
         if enabled:
             self.show()
-            canvas = self.getCanvas()
-            if canvas is not None:
+            for canvas in self.configuring_canvases:
                 canvas.configure()
             self.raise_()
             self.setFloating(True)

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -433,8 +433,10 @@ class QVTKWidget(QCellWidget):
         self.mRenWin.GetSize()
         
         self.mRenWin.SetSize(width, height)
+        self.mRenWin.Modified()
         if self.mRenWin.GetInteractor():
-            self.mRenWin.GetInteractor().SetSize(width, height)
+            self.mRenWin.GetInteractor().UpdateSize(width, height)
+            self.mRenWin.GetInteractor().InvokeEvent(vtk.vtkCommand.ConfigureEvent)
 
     def resizeEvent(self, e):
         """ resizeEvent(e: QEvent) -> None


### PR DESCRIPTION
This adds access to the VCS2D interaction functionality that I created to the GUI. It also fixes some long-standing issues with how window resize events were getting propagated in VTKCell– I had to manually trigger the RenderWindow's Modified event, as well as the ConfigureEvent on the Interactor, which makes the resize inside the VTKCell act just like the events passed by the standard VTKRenderWindow's resize stuff.
