### PR TITLE
Adds a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+The [UV-CDAT project](https://github.com/UV-CDAT/uvcdat) uses a modified
+version of the VisTrails data analysis tool for its provenance-enabled
+persistence and execution needs.
+
+Homepage: <http://www.vistrails.org>
+
+This version was forked off a long time ago for UV-CDAT use. For VisTrails 2.0+
+check out [VisTrails/VisTrails](https://github.com/VisTrails/VisTrails).


### PR DESCRIPTION
I got in touch with the Github team and removed this repository, UV-CDAT/VisTrails from the VisTrails/VisTrails network. It is no longer marked as a fork. This means that opening a pull-request from this repository will target itself instead of targeting VisTrails/VisTrails by default, preventing errors like [#956](https://github.com/VisTrails/VisTrails/pull/956), [#968](https://github.com/VisTrails/VisTrails/pull/968), [#999](https://github.com/VisTrails/VisTrails/pull/999), [#1000](https://github.com/VisTrails/VisTrails/pull/1000), [#1003](https://github.com/VisTrails/VisTrails/pull/1003), [#1004](https://github.com/VisTrails/VisTrails/pull/1004), [#1005](https://github.com/VisTrails/VisTrails/pull/1005).

Since there is no easy way on Github to see that relationship, this README ([rendered](https://github.com/UV-CDAT/VisTrails/blob/de3cd23dd14aacf82fb1ea7f8b0b88b52de06f62/README.md)) makes it clear what is going on. It also links to [UV-CDAT/uvcdat](https://github.com/UV-CDAT/uvcdat) since this is where the info on UV-CDAT and the issue tracking are.
