### PR TITLE
Control Click fixes

### DIFF
--- a/vistrails/packages/spreadsheet/spreadsheet_window.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_window.py
@@ -420,8 +420,7 @@ class SpreadsheetWindow(QtGui.QMainWindow):
                 if p and not p.isModal():
                     pos = p.viewport().mapFromGlobal(e.globalPos())
                     p.emit(QtCore.SIGNAL('cellActivated(int, int, bool)'),
-                           p.rowAt(pos.y()), p.columnAt(pos.x()),
-                           e.modifiers()==QtCore.Qt.ControlModifier)
+                           p.rowAt(pos.y()), p.columnAt(pos.x()), False)
             except AttributeError:
                 return False
         return False

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -511,8 +511,13 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        ctrl = (e.modifiers()&QtCore.Qt.ControlModifier)
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
         isDoubleClick = e.type()==QtCore.QEvent.MouseButtonDblClick
+
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
                                       ctrl,
                                       (e.modifiers()&QtCore.Qt.ShiftModifier),
@@ -543,8 +548,13 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
-                                      (e.modifiers()&QtCore.Qt.ControlModifier),
+                                      ctrl,
                                       (e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0), 0, None)
 
@@ -581,8 +591,13 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
-                                      (e.modifiers()&QtCore.Qt.ControlModifier),
+                                      ctrl,
                                       (e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0),0,None)
 
@@ -615,7 +630,11 @@ class QVTKWidget(QCellWidget):
             keysym = self.qt_key_to_key_sym(e.key())
 
         # Ignore 'q' or 'e' or Ctrl-anykey
-        ctrl = (e.modifiers()&QtCore.Qt.ControlModifier)
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
         shift = (e.modifiers()&QtCore.Qt.ShiftModifier)
         if (keysym in ['q', 'e'] or ctrl):
             e.ignore()
@@ -649,7 +668,10 @@ class QVTKWidget(QCellWidget):
             keysym = self.qt_key_to_key_sym(e.key())
 
         # Ignore 'q' or 'e' or Ctrl-anykey
-        ctrl = (e.modifiers()&QtCore.Qt.ControlModifier)
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
         shift = (e.modifiers()&QtCore.Qt.ShiftModifier)
         if (keysym in ['q','e'] or ctrl):
             e.ignore()
@@ -667,9 +689,12 @@ class QVTKWidget(QCellWidget):
 
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
-
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
-                                      (e.modifiers()&QtCore.Qt.ControlModifier),
+                                      ctrl,
                                       (e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0),0,None)
         
@@ -703,7 +728,12 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        ctrl = int(e.modifiers()&QtCore.Qt.ControlModifier)
+        if sys.platform == "darwin":
+            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
+        else:
+            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+        ctrl = int(ctrl)
+
         shift = int(e.modifiers()&QtCore.Qt.ShiftModifier)
         self.iren.SetEventInformationFlipY(e.x(),e.y(),ctrl,shift,chr(0),0,None)
         self.iren.InvokeEvent("ContextMenuEvent")

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -511,16 +511,14 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
 
         isDoubleClick = e.type()==QtCore.QEvent.MouseButtonDblClick
 
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
                                       ctrl,
-                                      (e.modifiers()&QtCore.Qt.ShiftModifier),
+                                      bool(e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0),
                                       isDoubleClick,
                                       None)
@@ -532,7 +530,6 @@ class QVTKWidget(QCellWidget):
 
         if ctrl:
             e.ignore()
-            return
 
         self.interacting = self.getActiveRenderer(self.iren)
         
@@ -548,14 +545,12 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
 
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
                                       ctrl,
-                                      (e.modifiers()&QtCore.Qt.ShiftModifier),
+                                      bool(e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0), 0, None)
 
         self.iren.InvokeEvent("MouseMoveEvent")
@@ -591,14 +586,12 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
 
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
                                       ctrl,
-                                      (e.modifiers()&QtCore.Qt.ShiftModifier),
+                                      bool(e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0),0,None)
 
         invoke = {QtCore.Qt.LeftButton:"LeftButtonReleaseEvent",
@@ -630,12 +623,10 @@ class QVTKWidget(QCellWidget):
             keysym = self.qt_key_to_key_sym(e.key())
 
         # Ignore 'q' or 'e' or Ctrl-anykey
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
 
-        shift = (e.modifiers()&QtCore.Qt.ShiftModifier)
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
+
+        shift = bool(e.modifiers()&QtCore.Qt.ShiftModifier)
         if (keysym in ['q', 'e'] or ctrl):
             e.ignore()
             return
@@ -668,11 +659,9 @@ class QVTKWidget(QCellWidget):
             keysym = self.qt_key_to_key_sym(e.key())
 
         # Ignore 'q' or 'e' or Ctrl-anykey
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
-        shift = (e.modifiers()&QtCore.Qt.ShiftModifier)
+
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
+        shift = bool(e.modifiers()&QtCore.Qt.ShiftModifier)
         if (keysym in ['q','e'] or ctrl):
             e.ignore()
             return
@@ -689,13 +678,11 @@ class QVTKWidget(QCellWidget):
 
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
+
+        ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
         self.iren.SetEventInformationFlipY(e.x(),e.y(),
                                       ctrl,
-                                      (e.modifiers()&QtCore.Qt.ShiftModifier),
+                                      bool(e.modifiers()&QtCore.Qt.ShiftModifier),
                                       chr(0),0,None)
         
         self.SelectActiveRenderer(self.iren)
@@ -728,11 +715,7 @@ class QVTKWidget(QCellWidget):
         if (not self.iren) or (not self.iren.GetEnabled()):
             return
 
-        if sys.platform == "darwin":
-            ctrl = (e.modifiers() & QtCore.Qt.MetaModifier)
-        else:
-            ctrl = (e.modifiers() & QtCore.Qt.ControlModifier)
-        ctrl = int(ctrl)
+        ctrl = int(e.modifiers() & QtCore.Qt.ControlModifier)
 
         shift = int(e.modifiers()&QtCore.Qt.ShiftModifier)
         self.iren.SetEventInformationFlipY(e.x(),e.y(),ctrl,shift,chr(0),0,None)


### PR DESCRIPTION
This goes with UV-CDAT/uvcdat#1163. There are a number of issues with modified clicks in Qt– for one, it reads ctrl + left on a mac as a right click. Presumably to work around this, they map the control modifier to the command button, and the meta modifier to the control button. I originally changed it to use the meta button, but that led me to discover the issue with Qt interpreting ctrl+left as a right click. 

Another issue that was happening is that VTK doesn't know how to interpret the Qt Keyboard Modifier objects– it would wind up setting the interactor's ControlKey and ShiftKey attributes to ridiculously high numbers that would evaluate to truth-y, but wouldn't be `== True`, which was the check I tend to use.

A third issue is that since I now use the command key as a modifier, command clicking inside a cell in the spreadsheet would toggle it to unselected. This was annoying, and it doesn't look like it's actually a useful feature at all, so I just made it so we don't pass the control modifier to the `cellActivated` function, and instead pass `False` for the `toggle` value.

@remram44 @doutriaux1 If you can test this on Ubuntu, that'd be great… my mac is converting the control + left click into a right click before it gets through to my VM, so I'm not certain if it's set up correctly there. 
