### PR TITLE
Fixes Q/E support

### DIFF
--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -622,12 +622,12 @@ class QVTKWidget(QCellWidget):
         if not keysym:
             keysym = self.qt_key_to_key_sym(e.key())
 
-        # Ignore 'q' or 'e' or Ctrl-anykey
+        # Ignore Ctrl-anykey
 
         ctrl = bool(e.modifiers() & QtCore.Qt.ControlModifier)
 
         shift = bool(e.modifiers()&QtCore.Qt.ShiftModifier)
-        if (keysym in ['q', 'e'] or ctrl):
+        if ctrl:
             e.ignore()
             return
         


### PR DESCRIPTION
Looks like 'q' and 'e' already weren't doing anything in the app, so ignoring them just broke my text editing.

To test if this works:

Click the Configuration Pencil in the plot options

Click the Text Button
![screen shot 2015-04-01 at 8 28 21 am](https://cloud.githubusercontent.com/assets/718512/6944563/2e23414c-d849-11e4-85cf-0ea140649163.png)

Click anywhere to drop a new text box
![screen shot 2015-04-01 at 8 28 38 am](https://cloud.githubusercontent.com/assets/718512/6944561/2e1fabcc-d849-11e4-927d-fcf84652db2e.png)

Type "q" and "e"
![screen shot 2015-04-01 at 8 28 44 am](https://cloud.githubusercontent.com/assets/718512/6944562/2e22b9ca-d849-11e4-8779-79714af56bd7.png)

Prior to this, nothing would happen.

@remram44 
