### PR TITLE
Don't create $HOME/tmp directory, unused

### DIFF
--- a/vistrails/gui/uvcdat/diagnosticsDockWidget.py
+++ b/vistrails/gui/uvcdat/diagnosticsDockWidget.py
@@ -58,10 +58,6 @@ class DiagnosticsDockWidget(QtGui.QDockWidget, Ui_DiagnosticDockWidget):
       self.DS2PathLabel.setText('/')
       self.obs1PathLabel.setText('/')
       self.obs2PathLabel.setText('/')
-        
-      self.tmppth = os.path.join(os.environ['HOME'],"tmp")
-      if not os.path.exists(self.tmppth):
-         os.makedirs(self.tmppth)
 
       self.DiagnosticGroup = None
       self.diagnostic_set = None
@@ -712,11 +708,6 @@ class DiagnosticsDockWidget(QtGui.QDockWidget, Ui_DiagnosticDockWidget):
            print "auxiliary option: %s" % auxname
            print "region_box: %s" %self.region_box
            print "season: %s" % season
-        # initial test, first cut:
-        # This stuff should go elsewhere...
-        import os
-        #...was self.filetable2 = setup_filetable(self.path2,self.tmppth,search_filter=filt2)
-        # ( replacement moved to __init__ and plotsetchanged)
         model = []
         obs = []
         if self.useDS1 == 1:


### PR DESCRIPTION
Introduced in [`44bcd3c4`](https://github.com/UV-CDAT/VisTrails/commit/44bcd3c4aa6f338c6d8e8d136cd4415fc9cc4519#diff-e3f42e06ba400d2914ca8aa9f90adbc2R129).

Not only is this directory created where it shouldn't, it doesn't appear to be used anymore.
