### PR TITLE
Disables PVClimate in plot registry

### DIFF
--- a/vistrails/core/uvcdat/plots/registry.cfg
+++ b/vistrails/core/uvcdat/plots/registry.cfg
@@ -11,10 +11,10 @@
 #codepath = VTK
 #config_file = registry.cfg
 
-[PVClimate]
-codepath = PVClimate
-config_file = registry.cfg
-helper = packages.pvclimate.pvclimate_pipeline_helper.PVClimatePipelineHelper
+#[PVClimate]
+#codepath = PVClimate
+#config_file = registry.cfg
+#helper = packages.pvclimate.pvclimate_pipeline_helper.PVClimatePipelineHelper
 
 #[VisIt]
 #codepath = VisIt


### PR DESCRIPTION
It doesn't seem like they load correctly:

```
parse_helper_type_str('packages.pvclimate.pvclimate_pipeline_helper.PVClimatePipelineHelper')
PVClimate plots not loaded.
Error when loading package_config_file: /home/remram/Documents/programming/uvcdat-vistrails/vistrails/core/uvcdat/plots/PVClimate/registry.cfg No module named paraview.simple
Traceback (most recent call last):
  File "/home/remram/Documents/programming/uvcdat-vistrails/vistrails/core/uvcdat/plotmanager.py", line 106, in load_plots
    helper = self.parse_helper_type_str(pkg_parser.get(p, 'helper'))
  File "/home/remram/Documents/programming/uvcdat-vistrails/vistrails/core/uvcdat/plotmanager.py", line 80, in parse_helper_type_str
    module = __import__(path, globals(), locals(), [klass_name])
  File "/home/remram/Documents/programming/uvcdat-vistrails/vistrails/packages/pvclimate/pvclimate_pipeline_helper.py", line 25, in <module>
    from pvgenericcell import *
  File "/home/remram/Documents/programming/uvcdat-vistrails/vistrails/packages/pvclimate/pvgenericcell.py", line 12, in <module>
    import paraview.simple as pvsp
ImportError: No module named paraview.simple
```

Should they be removed from `registry.cfg`?
