### PR TITLE
Don't call saveToPNG(None) on QCDATWidget

### DIFF
--- a/vistrails/packages/uvcdat_cdms/init.py
+++ b/vistrails/packages/uvcdat_cdms/init.py
@@ -18,6 +18,7 @@ import MV2
 import os
 import ast
 import string
+import tempfile
 from info import identifier
 from widgets import GraphicsMethodConfigurationWidget
 from core.configuration import get_vistrails_configuration
@@ -1501,6 +1502,20 @@ class QCDATWidget(QVTKWidget):
             self.canvas.gif(filename)#, width=11.5)
         elif ext.upper() == ".PS":
             self.canvas.postscript(filename)#, width=11.5)
+
+    def grabWindowPixmap(self):
+        """ grabWindowImage() -> QPixmap
+        Widget special grabbing function
+
+        """
+        fd, filename = tempfile.mkstemp(prefix='vt_vcs_exportcell_',
+                                        suffix='.png')
+        os.close(fd)
+        try:
+            self.saveToPNG(filename)
+            return QtGui.QPixmap(filename, 'PNG')
+        finally:
+            os.remove(filename)
 
     def saveToPNG(self, filename):
         """ saveToPNG(filename: str) -> bool


### PR DESCRIPTION
Since `QCDATWidget#saveToPNG()` doesn't support `filename=None`, like is documented in superclass QVTKWidget, we need to replace the grabWindowPixmap() logic.

Alternatively support could be added to `vcs.Canvas:Canvas#png()` for `file=None`; see @rexissimus's [patch](https://github.com/UV-CDAT/uvcdat/issues/1276#issuecomment-111177839).

Fixes UV-CDAT/uvcdat#1276
