### PR TITLE
Fixes toolbar not going away when cell is cleared

### DIFF
--- a/vistrails/packages/spreadsheet/spreadsheet_sheet.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_sheet.py
@@ -485,6 +485,8 @@ class StandardWidgetSheet(QtGui.QTableWidget):
         self.setCellWidget(row, col, cellWidget)
         if cellWidget:
             self.delegate.updateEditorGeometry(cellWidget, None, index)
+        if (row, col) == self.activeCell:
+            self.setActiveCell(row, col)
 
     def selectCell(self, row, col, toggling):
         """ selectCell(row: int, col: int, toggling: bool) -> None


### PR DESCRIPTION
Makes the cell toolbar go away when the cell is cleared.

VisTrails PR: VisTrails/VisTrails#1073

Fixes UV-CDAT/uvcdat#1275
