### PR TITLE
Fixes sub-selecting slabs that has one-value axes

### DIFF
--- a/vistrails/gui/uvcdat/project_controller.py
+++ b/vistrails/gui/uvcdat/project_controller.py
@@ -369,6 +369,18 @@ class ProjectController(QtCore.QObject):
             new_var.axesOperations = axesOperations
             self.add_defined_variable(new_var)
                 
+    def get_axes_info(self, name):
+        """ returns [axes, axesOperations] for an existing variable
+
+        """
+        if name in self.computed_variables_ops:
+            return (self.computed_variables_ops[name].axes,
+                    self.computed_variables_ops[name].axesOperations)
+        elif name in self.defined_variables:
+            return (self.defined_variables[name].axes,
+                    self.defined_variables[name].axesOperations)
+        return None
+
     def emit_defined_variable(self, var):
         import cdms2
         from packages.uvcdat_cdms.init import CDMSVariable, CDMSVariableOperation

--- a/vistrails/gui/uvcdat/variable.py
+++ b/vistrails/gui/uvcdat/variable.py
@@ -696,6 +696,20 @@ class VariableProperties(QtGui.QDialog):
 
         _app = get_vistrails_application()
         controller = _app.uvcdatWindow.get_current_project_controller()
+
+        # Add old collapsed axes
+        axes_info = controller.get_axes_info(original_id)
+        if axes_info:
+            old_axes, old_axes_operations = axes_info
+            # FIXME: Update old_axes_operations?
+            def getKWArgs(**_kwargs):
+                return _kwargs
+            old_kwargs = eval('getKWArgs(%s)' % old_axes)
+
+            for key in old_kwargs:
+                if key not in kwargs:
+                    kwargs[key] = old_kwargs[key]
+
         def get_kwargs_str(kwargs_dict):
             kwargs_str = ""
             for k, v in kwargs_dict.iteritems():


### PR DESCRIPTION
One-value axes were not added to the final axes and got reset when edited.

vistrails/gui/uvcdat/project_controller.py:
- get_axes_info: *new
  Extracts axes info from computed or defined variables

vistrails/gui/uvcdat/variable.py:
- getUpdatedVar:
  Add already defined axes to final axes.

Fixes https://github.com/UV-CDAT/uvcdat/issues/1466
